### PR TITLE
Add schema.org metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,3 +278,62 @@ Initial version, including only `train` set.
 For any questions/suggestions/comments/corrections, please open an issue in this
 github repository. In particular, we plan to maintain and release new versions
 of the ground-truth as corrections are found.
+
+## Dataset Metadata
+The following table is necessary for this dataset to be indexed by search
+engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
+<div itemscope itemtype="http://schema.org/Dataset">
+  <table>
+    <tr>
+      <th>property</th>
+      <th>value</th>
+    </tr>
+    <tr>
+      <td>name</td>
+      <td><code itemprop="name">Google Landmarks Dahttps://avatars1.githubusercontent.com/u/1870149?s=40&v=4taset v2</code></td>
+    </tr>
+    <tr>
+      <td>alternateName</td>
+      <td><code itemprop="name">Learning to Detect Manipulated Facial Images</code></td>
+    </tr>
+    <tr>
+      <td>description</td>
+      <td><code itemprop="description">FaceForensics++ is a forensics dataset consisting of 1000 original video sequences that have been manipulated with four automated face manipulation methods: Deepfakes, Face2Face, FaceSwap and NeuralTextures. The data has been sourced from 977 youtube videos and all videos contain a trackable mostly frontal face without occlusions which enables automated tampering methods to generate realistic forgeries. As we provide binary masks the data can be used for image and video classification as well as segmentation. In addition, we provide 1000 Deepfakes models to generate and augment new data.
+
+For more information, please consult our <a href="https://arxiv.org/abs/1901.08971">updated paper</a>.</code></td>
+    </tr>
+    <tr>
+      <td>sameAs</td>
+      <td><code itemprop="sameAs">https://github.com/ondyari/FaceForensics/</code></td>
+    </tr>
+    <tr>
+      <td>provider</td>
+      <td>
+        <div itemscope itemtype="http://schema.org/Organization" itemprop="provider">
+          <table>
+            <tr>
+              <th>property</th>
+              <th>value</th>
+            </tr>
+            <tr>
+              <td>name</td>
+              <td><code itemprop="name">Google</code></td>
+            </tr>
+            <tr>
+              <td>sameAs</td>
+              <td><code itemprop="sameAs">https://en.wikipedia.org/wiki/Google</code></td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>citation</td>
+      <td><code itemprop="citation">https://arxiv.org/abs/1901.08971</code></td>
+    </tr>
+    <tr>
+      <td>license</td>
+      <td><code itemprop="license">The data is released under the <a href="http://kaldir.vc.in.tum.de/faceforensics_tos.pdf">FaceForensics Terms of Use</a></code></td>
+    </tr>
+  </table>
+</div>


### PR DESCRIPTION
Adds metadata so that search engines such as Dataset Search (g.co/datasetsearch) can index it. See https://medium.com/@ChrisGorgo/making-github-hosted-datasets-discoverable-by-google-dataset-search-13527f2f657a for details.

Tested: Structured data testing tool