### PR TITLE
fixed broken link to baseline models

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ stored in `0/1/2/0123456789abcdef.jpg`.
 
 We make available the ResNet101-ArcFace baseline model from the paper, see
 instructions
-[here](https://github.com/tensorflow/models/tree/master/research/delf/delf/python/google_landmarks_dataset).
+[here](https://github.com/tensorflow/models/tree/master/research/delf/delf/python/datasets/google_landmarks_dataset).
 
 ## Metric computation code
 


### PR DESCRIPTION
The link to the ResNet101-ArcFace baseline model in the README.md is broken, fixed with correct one